### PR TITLE
utils.InputBox should return the default value if cancelled

### DIFF
--- a/foo_spider_monkey_panel/js_objects/utils.cpp
+++ b/foo_spider_monkey_panel/js_objects/utils.cpp
@@ -589,7 +589,7 @@ JsUtils::InputBox( uint32_t hWnd, const pfc::string8_fast& prompt, const pfc::st
         }        
     }
 
-    return pfc::string8_fast();
+    return def;
 }
 
 std::optional<pfc::string8_fast>


### PR DESCRIPTION
Currently, it returns an empty string. 

This only applies when "error_on_cancel" is not set or false. An error is correctly thrown if set to true.

```
    /*
    Example1:
    var username = utils.InputBox(window.ID, "Enter your username", "Spider Monkey Panel", "");
    With "error_on_cancel" not set (or set to false), cancelling the dialog will return "defaultval".
    Example2:
    Using Example1, you can't tell if OK or Cancel was pressed if the return value is the same
    as "defaultval". If you need to know, set "error_on_cancel" to true which throws a script error
    when Cancel is pressed.
    try {
        var username = utils.InputBox(window.ID, "Enter your username", "Spider Monkey Panel", "", true);
        // OK was pressed.
    } catch(e) {
        // Dialog was closed by pressing Esc, Cancel or the Close button.
    }
    */
```

