### PR TITLE
Fixing setup.py

### DIFF
--- a/scripts/unpack_mozjs.py
+++ b/scripts/unpack_mozjs.py
@@ -35,8 +35,8 @@ def unpack():
 
     with ZipFile(zip_arc) as z:
         z.extractall(output_dir)
-        
-    restore_timestamps(zip, output_dir)
+
+    restore_timestamps(zip_arc, output_dir)
 
 if __name__ == '__main__':
     call_wrapper.final_call_decorator(


### PR DESCRIPTION
Was getting errors running setup.py because `AttributeError: type object 'zip' has no attribute 'seek'`. I think this fixes the problem, although I'm not seeing any changes to timestamps, so maybe I'm not doing something right.