### PR TITLE
Substantially improved fb2k startup and script initialization 

### DIFF
--- a/foo_spider_monkey_panel/dllmain.cpp
+++ b/foo_spider_monkey_panel/dllmain.cpp
@@ -76,7 +76,6 @@ void InitializeSubsystems( HINSTANCE ins )
             g_subsystem_failures[SubsystemId::SMP_GDIPLUS] = { "GdiplusStartup failed", static_cast<uint32_t>( gdiRet ) };
         }
     }
-
 }
 
 void InitializeDelayedSubsystems( HINSTANCE ins )


### PR DESCRIPTION
...by deferring call to InitializeSubsytems to the on_init() callback.

See full discussion [here](https://hydrogenaud.io/index.php?topic=114686.175) and discussion of fix [here](https://hydrogenaud.io/index.php?topic=114686.msg997642#msg997642).

This _seems_ safe to do, but maybe there's a reason it must be done in DLL_PROCESS_ATTACH that I'm unaware of.