### PR TITLE
Improve accuracy of CalcTextWidth if selected font has kerning pairs

### DIFF
--- a/component/docs/js/foo_spider_monkey_panel.js
+++ b/component/docs/js/foo_spider_monkey_panel.js
@@ -3191,12 +3191,17 @@ function GdiGraphics() {
 
     /**
      * Calculates text width for {@link GdiGraphics#GdiDrawText}.
+     * 
+     * Note: When the str contains a kerning pair that is found in the specified 
+     * font, the return value will be larger than the actual drawn width of the
+     * text. If accurate values are required, set use_exact to true.
      *
      * @param {string} str
      * @param {GdiFont} font
+     * @param {boolean=} [use_exact=false] Uses a slower, but more accurate method of calculating text width which accounts for kerning pairs.  
      * @return {number}
      */
-    this.CalcTextWidth = function (str, font) { }; // (uint)
+    this.CalcTextWidth = function (str, font, use_exact) { }; // (uint)
 
     /**
      * @param {number} x

--- a/foo_spider_monkey_panel/js_objects/gdi_graphics.cpp
+++ b/foo_spider_monkey_panel/js_objects/gdi_graphics.cpp
@@ -155,7 +155,7 @@ uint32_t JsGdiGraphics::CalcTextWidth( const std::wstring& str, JsGdiFont* font 
     qwr::final_action autoHdcReleaser( [hDc, pGdi = pGdi_] { pGdi->ReleaseHDC( hDc ); } );
     gdi::ObjectSelector autoFont( hDc, font->GetHFont() );
 
-    return smp::utils::get_text_width( hDc, str );
+    return smp::utils::get_text_width( hDc, str, true );
 }
 
 void JsGdiGraphics::DrawEllipse( float x, float y, float w, float h, float line_width, uint32_t colour )

--- a/foo_spider_monkey_panel/js_objects/gdi_graphics.cpp
+++ b/foo_spider_monkey_panel/js_objects/gdi_graphics.cpp
@@ -44,7 +44,7 @@ JSClass jsClass = {
 };
 
 MJS_DEFINE_JS_FN_FROM_NATIVE( CalcTextHeight, JsGdiGraphics::CalcTextHeight )
-MJS_DEFINE_JS_FN_FROM_NATIVE( CalcTextWidth, JsGdiGraphics::CalcTextWidth )
+MJS_DEFINE_JS_FN_FROM_NATIVE_WITH_OPT( CalcTextWidth, JsGdiGraphics::CalcTextWidth, JsGdiGraphics::CalcTextWidthWithOpt, 1 )
 MJS_DEFINE_JS_FN_FROM_NATIVE( DrawEllipse, JsGdiGraphics::DrawEllipse )
 MJS_DEFINE_JS_FN_FROM_NATIVE_WITH_OPT( DrawImage, JsGdiGraphics::DrawImage, JsGdiGraphics::DrawImageWithOpt, 2 )
 MJS_DEFINE_JS_FN_FROM_NATIVE( DrawLine, JsGdiGraphics::DrawLine )
@@ -146,7 +146,7 @@ uint32_t JsGdiGraphics::CalcTextHeight( const std::wstring& str, JsGdiFont* font
     return smp::utils::get_text_height( hDc, str );
 }
 
-uint32_t JsGdiGraphics::CalcTextWidth( const std::wstring& str, JsGdiFont* font )
+uint32_t JsGdiGraphics::CalcTextWidth( const std::wstring& str, JsGdiFont* font, boolean use_exact )
 {
     qwr::QwrException::ExpectTrue( pGdi_, "Internal error: Gdiplus::Graphics object is null" );
     qwr::QwrException::ExpectTrue( font, "font argument is null" );
@@ -155,7 +155,21 @@ uint32_t JsGdiGraphics::CalcTextWidth( const std::wstring& str, JsGdiFont* font 
     qwr::final_action autoHdcReleaser( [hDc, pGdi = pGdi_] { pGdi->ReleaseHDC( hDc ); } );
     gdi::ObjectSelector autoFont( hDc, font->GetHFont() );
 
-    return smp::utils::get_text_width( hDc, str, true );
+    return smp::utils::get_text_width( hDc, str, use_exact );
+}
+
+uint32_t JsGdiGraphics::CalcTextWidthWithOpt( size_t optArgCount, const std::wstring& str, 
+                                          JsGdiFont* font, boolean use_exact )
+{
+    switch ( optArgCount )
+    {
+    case 0:
+        return CalcTextWidth( str, font, use_exact );
+    case 1:
+        return CalcTextWidth( str, font );
+    default:
+        throw qwr::QwrException( "Internal error: invalid number of optional arguments specified: {}", optArgCount );
+    }
 }
 
 void JsGdiGraphics::DrawEllipse( float x, float y, float w, float h, float line_width, uint32_t colour )

--- a/foo_spider_monkey_panel/js_objects/gdi_graphics.h
+++ b/foo_spider_monkey_panel/js_objects/gdi_graphics.h
@@ -45,7 +45,8 @@ public:
 
 public:
     uint32_t CalcTextHeight( const std::wstring& str, JsGdiFont* font );
-    uint32_t CalcTextWidth( const std::wstring& str, JsGdiFont* font );
+    uint32_t CalcTextWidth( const std::wstring& str, JsGdiFont* font, boolean use_exact = false );
+    uint32_t CalcTextWidthWithOpt( size_t optArgCount, const std::wstring& str, JsGdiFont* font, boolean use_exact );
     void DrawEllipse( float x, float y, float w, float h, float line_width, uint32_t colour );
     void DrawImage( JsGdiBitmap* image,
                     float dstX, float dstY, float dstW, float dstH,

--- a/foo_spider_monkey_panel/utils/text_helpers.cpp
+++ b/foo_spider_monkey_panel/utils/text_helpers.cpp
@@ -111,14 +111,13 @@ size_t get_text_height( HDC hdc, std::wstring_view text )
     return static_cast<size_t>( size.cy );
 }
 
-size_t get_text_width( HDC hdc, std::wstring_view text )
+size_t get_text_width( HDC hdc, std::wstring_view text, bool accurate )
 {
     SIZE size;
-    size_t count = GetKerningPairs( hdc, 0, 0 );
-    if ( count > 0 )
+    // If font has kerning pairs then GetTextExtentPoint32 will return an inaccurate width if those pairs exist in text.
+    // DrawText returns a completely accurate value, but is slower and should not be called from inside estimate_line_wrap
+    if ( accurate && GetKerningPairs( hdc, 0, 0 ) > 0 )
     {
-        // If font has kerning pairs then GetTextExtentPoint32 will return an incorrect width if those pairs exist in text.
-        // Use DrawText in this case to provide more accurate values.
         RECT rc_calc{ 0, 0, 0, 0 };
         DrawText( hdc, text.data(), -1, &rc_calc, DT_CALCRECT );
         return rc_calc.right;

--- a/foo_spider_monkey_panel/utils/text_helpers.cpp
+++ b/foo_spider_monkey_panel/utils/text_helpers.cpp
@@ -114,8 +114,20 @@ size_t get_text_height( HDC hdc, std::wstring_view text )
 size_t get_text_width( HDC hdc, std::wstring_view text )
 {
     SIZE size;
-    // TODO: add error checks
-    GetTextExtentPoint32( hdc, text.data(), static_cast<int>( text.size() ), &size );
+    size_t count = GetKerningPairs( hdc, 0, 0 );
+    if ( count > 0 )
+    {
+        // If font has kerning pairs then GetTextExtentPoint32 will return an incorrect width if those pairs exist in text.
+        // Use DrawText in this case to provide more accurate values.
+        RECT rc_calc{ 0, 0, 0, 0 };
+        DrawText( hdc, text.data(), -1, &rc_calc, DT_CALCRECT );
+        return rc_calc.right;
+    }
+    else
+    {
+        // TODO: add error checks
+        GetTextExtentPoint32( hdc, text.data(), static_cast<int>( text.size() ), &size );
+    }
     return static_cast<size_t>( size.cx );
 }
 

--- a/foo_spider_monkey_panel/utils/text_helpers.cpp
+++ b/foo_spider_monkey_panel/utils/text_helpers.cpp
@@ -116,10 +116,10 @@ size_t get_text_width( HDC hdc, std::wstring_view text, bool accurate )
     SIZE size;
     // If font has kerning pairs then GetTextExtentPoint32 will return an inaccurate width if those pairs exist in text.
     // DrawText returns a completely accurate value, but is slower and should not be called from inside estimate_line_wrap
-    if ( accurate && GetKerningPairs( hdc, 0, 0 ) > 0 )
+    if ( accurate && text.size() > 1 && GetKerningPairs( hdc, 0, 0 ) > 0 )
     {
         RECT rc_calc{ 0, 0, 0, 0 };
-        DrawText( hdc, text.data(), -1, &rc_calc, DT_CALCRECT );
+        DrawText( hdc, text.data(), -1, &rc_calc, DT_CALCRECT | DT_NOPREFIX );
         return rc_calc.right;
     }
     else

--- a/foo_spider_monkey_panel/utils/text_helpers.cpp
+++ b/foo_spider_monkey_panel/utils/text_helpers.cpp
@@ -113,21 +113,21 @@ size_t get_text_height( HDC hdc, std::wstring_view text )
 
 size_t get_text_width( HDC hdc, std::wstring_view text, bool accurate )
 {
-    SIZE size;
     // If font has kerning pairs then GetTextExtentPoint32 will return an inaccurate width if those pairs exist in text.
     // DrawText returns a completely accurate value, but is slower and should not be called from inside estimate_line_wrap
     if ( accurate && text.size() > 1 && GetKerningPairs( hdc, 0, 0 ) > 0 )
     {
         RECT rc_calc{ 0, 0, 0, 0 };
-        DrawText( hdc, text.data(), -1, &rc_calc, DT_CALCRECT | DT_NOPREFIX );
+        DrawText( hdc, text.data(), -1, &rc_calc, DT_CALCRECT | DT_NOPREFIX | DT_SINGLELINE );
         return rc_calc.right;
     }
     else
     {
+        SIZE size;
         // TODO: add error checks
         GetTextExtentPoint32( hdc, text.data(), static_cast<int>( text.size() ), &size );
+        return static_cast<size_t>( size.cx );
     }
-    return static_cast<size_t>( size.cx );
 }
 
 std::vector<wrapped_item> estimate_line_wrap( HDC hdc, const std::wstring& text, size_t width )

--- a/foo_spider_monkey_panel/utils/text_helpers.h
+++ b/foo_spider_monkey_panel/utils/text_helpers.h
@@ -7,7 +7,7 @@ namespace smp::utils
 {
 
 size_t get_text_height( HDC hdc, std::wstring_view text );
-size_t get_text_width( HDC hdc, std::wstring_view text );
+size_t get_text_width( HDC hdc, std::wstring_view text, bool accurate = false );
 
 struct wrapped_item
 {


### PR DESCRIPTION
I discovered that if a font has kerning pairs and the text you wish to get the width of contains one (or more) of those pairs the value of `CalcTextWidth` will be off for each pair in the text. I couple **Yo**u's or **To**'s and things get really bad really quickly (the cursor and highlighted text should be directly adjacent to the previous Y):

![bad calc](https://i.stack.imgur.com/FyauM.png)

See discussion [here](https://stackoverflow.com/questions/67683932/how-to-force-gettextextentpoint32-to-take-into-account-kerning?noredirect=1#comment119648000_67683932) where the suggestion was made to switch to using `DrawText` with `DT_CALCRECT`.

I made the change and now things look good again:

![image](https://user-images.githubusercontent.com/2282004/119552519-3cd47a00-bd60-11eb-943e-f48fe8d12e40.png)

In the process of investigating I also discovered that despite the documentation, `GdiDrawText` does _not_ return:
```
     * @return {Array<number>}
     *     index | meaning <br>
     *     [0] left   (DT_CALCRECT) <br>
     *     [1] top    (DT_CALCRECT) <br>
     *     [2] right  (DT_CALCRECT) <br>
     *     [3] bottom (DT_CALCRECT) <br>
     *     [4] characters drawn
```
even if DT_CALCRECT flag is set. I had no idea how you wanted to handle that, so I left it as is.
