### PR TITLE
Fix JsFbMetadbHandle::GetFileInfo

### DIFF
--- a/foo_spider_monkey_panel/js_objects/fb_metadb_handle.cpp
+++ b/foo_spider_monkey_panel/js_objects/fb_metadb_handle.cpp
@@ -127,12 +127,7 @@ bool JsFbMetadbHandle::Compare( JsFbMetadbHandle* handle )
 
 JSObject* JsFbMetadbHandle::GetFileInfo()
 {
-    metadb_info_container::ptr containerInfo;
-    if ( !metadbHandle_->get_info_ref( containerInfo ) )
-    { // Not an error: info not loaded yet
-        return nullptr;
-    }
-
+    metadb_info_container::ptr containerInfo = metadbHandle_->get_info_ref();
     return JsFbFileInfo::CreateJs( pJsCtx_, containerInfo );
 }
 


### PR DESCRIPTION
This uses the simplified method I detailed in the forum thread and should never return null.

https://hydrogenaud.io/index.php?topic=116669.msg1003033#msg1003033

Not tested as I used the editor built in to github!

edit: tested the appveyor build which works fine.