### PR TITLE
minor build fixes

### DIFF
--- a/foo_spider_monkey_panel/foo_spider_monkey_panel.vcxproj
+++ b/foo_spider_monkey_panel/foo_spider_monkey_panel.vcxproj
@@ -69,7 +69,8 @@
       <PreprocessorDefinitions>_WINDOWS;_USRDLL;_SILENCE_CXX20_U8PATH_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalOptions>/Zm200 /Zc:__cplusplus /Zc:preprocessor /experimental:newLambdaProcessor /Zc:char8_t- %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zm200 /Zc:__cplusplus /experimental:newLambdaProcessor /Zc:char8_t- %(AdditionalOptions)</AdditionalOptions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <DisableSpecificWarnings>5105;26812;33005</DisableSpecificWarnings>
       <TreatWarningAsError>true</TreatWarningAsError>

--- a/foo_spider_monkey_panel/js_objects/global_object.cpp
+++ b/foo_spider_monkey_panel/js_objects/global_object.cpp
@@ -110,10 +110,10 @@ auto FindSuitableFileForInclude( const fs::path& path, const std::span<const fs:
 
             if ( config::advanced::debug_log_extended_include_error )
             {
-                smp::utils::LogDebug( fmt::format(
+                smp::utils::LogDebug( fmt::format( fmt::runtime(
                     "`include()` failed:\n"
                     "  file `{}` coud not be found using the following search paths:\n"
-                    "    {}\n",
+                    "    {}\n" ),
                     fmt::join( searchPaths | ranges::views::transform( []( const auto& path ) { return fmt::format( "    `{}`", path.u8string() ); } ),
                                "\n  " ) ) );
             }

--- a/foo_spider_monkey_panel/utils/zip_utils.cpp
+++ b/foo_spider_monkey_panel/utils/zip_utils.cpp
@@ -18,7 +18,7 @@ void CheckMZip( mz_bool mzBool, const mz_zip_archive& mzZip, std::string_view fu
 {
     if ( !mzBool )
     {
-        const auto introMessage = fmt::format( introMessageFmt, std::forward<Args>( introMessageFmtArgs )... );
+        const auto introMessage = fmt::format( fmt::runtime( introMessageFmt ), std::forward<Args>( introMessageFmtArgs )... );
         throw qwr::QwrException( "{}{} failed with error {:#x}: {}", introMessage, functionName, mzZip.m_last_error, mz_zip_get_error_string( mzZip.m_last_error ) );
     }
 }

--- a/props/local_dependencies/mozjs.props
+++ b/props/local_dependencies/mozjs.props
@@ -3,7 +3,7 @@
     <ImportGroup Label="PropertySheets">
     </ImportGroup>
     <PropertyGroup>
-        <_PropertySheetDisplayName>pfc</_PropertySheetDisplayName>
+        <_PropertySheetDisplayName>mozjs</_PropertySheetDisplayName>
     </PropertyGroup>
     <PropertyGroup Label="UserMacros">
         <MozJsDirectory>$(MainDir)mozjs\</MozJsDirectory>

--- a/scripts/additional_files/lexilla.vcxproj
+++ b/scripts/additional_files/lexilla.vcxproj
@@ -10,6 +10,9 @@
       <Platform>Win32</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <PropertyGroup>
+    <ReplaceWildcardsInProjectItems>true</ReplaceWildcardsInProjectItems>
+  </PropertyGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{7CA4BBC9-83CA-42BE-84BB-8A98368FABAB}</ProjectGuid>

--- a/scripts/additional_files/scintilla.vcxproj
+++ b/scripts/additional_files/scintilla.vcxproj
@@ -10,6 +10,9 @@
       <Platform>Win32</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <PropertyGroup>
+    <ReplaceWildcardsInProjectItems>true</ReplaceWildcardsInProjectItems>
+  </PropertyGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{10B2A7EF-9089-4352-BA26-7E9AEF50987D}</ProjectGuid>

--- a/scripts/patch_submodules.py
+++ b/scripts/patch_submodules.py
@@ -8,7 +8,7 @@ import call_wrapper
 def patch():
     cur_dir = Path(__file__).parent.absolute()
     root_dir = cur_dir.parent
-    patches = [cur_dir/"patches"/p for p in ["scintilla.patch", "smp_2003.patch", "mozjs.patch", "cui.patch"]]
+    patches = [cur_dir/"patches"/p for p in ["scintilla.patch", "smp_2003.patch", "mozjs.patch", "cui.patch", "fb2k_utils.patch"]]
     for p in patches:
         assert(p.exists() and p.is_file())
 

--- a/scripts/patches/fb2k_utils.patch
+++ b/scripts/patches/fb2k_utils.patch
@@ -1,0 +1,13 @@
+diff --git a/submodules/fb2k_utils/src/qwr/qwr_exception.h b/submodules/fb2k_utils/src/qwr/qwr_exception.h
+index 7e75b04..de7a01c 100644
+--- a/submodules/fb2k_utils/src/qwr/qwr_exception.h
++++ b/submodules/fb2k_utils/src/qwr/qwr_exception.h
+@@ -12,7 +12,7 @@ class QwrException
+ public:
+     template <typename... Args>
+     explicit QwrException( qwr::u8string_view errorMessage, Args&&... errorMessageFmtArgs )
+-        : std::runtime_error( fmt::format( errorMessage, std::forward<Args>( errorMessageFmtArgs )... ) )
++        : std::runtime_error( fmt::format( fmt::runtime( errorMessage ), std::forward<Args>( errorMessageFmtArgs )... ) )
+     {
+     }
+


### PR DESCRIPTION
- fixes the displayname for mozjs.props
- adds a `ReplaceWildcardsInProjectItems` for scintilla/lexilla.vcxproj files, to get rid of the warning
- moves the /Zc:preprocessor directive to a `UseStandardPreprocessor` prop