### PR TITLE
Feature/gdi minor fixes

### DIFF
--- a/foo_spider_monkey_panel/js_objects/gdi_graphics.cpp
+++ b/foo_spider_monkey_panel/js_objects/gdi_graphics.cpp
@@ -285,11 +285,10 @@ void JsGdiGraphics::DrawRect( float x, float y, float w, float h, float line_wid
 void JsGdiGraphics::DrawRoundRect( float x, float y, float w, float h, float arc_width, float arc_height, float line_width, uint32_t colour )
 {
     qwr::QwrException::ExpectTrue( pGdi_, "Internal error: Gdiplus::Graphics object is null" );
-    qwr::QwrException::ExpectTrue( 2 * arc_width <= w && 2 * arc_height <= h, "Arc argument has invalid value" );
 
     Gdiplus::Pen pen( colour, line_width );
     Gdiplus::GraphicsPath gp;
-    GetRoundRectPath( gp, Gdiplus::RectF{ x, y, w, h }, arc_width, arc_height );
+    GetRoundRectPath( gp, Gdiplus::RectF{ x, y, w, h }, std::min( w / 2, arc_width ), std::min( h / 2, arc_height ) );
 
     Gdiplus::Status gdiRet = pen.SetStartCap( Gdiplus::LineCapRound );
     qwr::error::CheckGdi( gdiRet, "SetStartCap" );
@@ -435,12 +434,10 @@ void JsGdiGraphics::FillRoundRect( float x, float y, float w, float h, float arc
 {
     qwr::QwrException::ExpectTrue( pGdi_, "Internal error: Gdiplus::Graphics object is null" );
 
-    qwr::QwrException::ExpectTrue( 2 * arc_width <= w && 2 * arc_height <= h, "Arc argument has invalid value" );
-
     Gdiplus::SolidBrush br( colour );
     Gdiplus::GraphicsPath gp;
     const Gdiplus::RectF rect{ x, y, w, h };
-    GetRoundRectPath( gp, rect, arc_width, arc_height );
+    GetRoundRectPath( gp, rect, std::min( w / 2, arc_width ), std::min( h / 2, arc_height ) );
 
     Gdiplus::Status gdiRet = pGdi_->FillPath( &br, &gp );
     qwr::error::CheckGdi( gdiRet, "FillPath" );

--- a/foo_spider_monkey_panel/stdafx.h
+++ b/foo_spider_monkey_panel/stdafx.h
@@ -5,15 +5,21 @@
 
 // Spider Monkey ESR60 and CUI support only Win7+
 #define _WIN32_WINNT _WIN32_WINNT_WIN7
-#define WINVER _WIN32_WINNT_WIN7
+#define WINVER       _WIN32_WINNT_WIN7
+
+// enable GdiPlus v1.1 features (available since Vista+)
+#define GDIPVER      0x0110
 
 // Fix std min max conflicts
-#define NOMINMAX
+#define NOMINMAX     1
+
 #include <algorithm>
+
 namespace Gdiplus
 {
-using std::min;
-using std::max;
+    // note: not needed on SDK 19041+
+    using std::min;
+    using std::max;
 };
 
 #include <WinSock2.h>


### PR DESCRIPTION
some minor drawing related fixes:
- `#define GDIPVER 0x0110` in `stdafx.h`: since we're on Win7+ already (needs Vista+). (will be useful for DWrite later, and some other things)
- some clipping/visibility related optimizations is `js_panel_window.cpp`
- lax arc_width/height checks in `Draw`/`FillUpdateRect`: instead of an error, clamp arc_width/height as w/2 and h/2 respectively.