### PR TITLE
minor build fixes (continued)

### DIFF
--- a/foo_spider_monkey_panel/convert/js_to_native.h
+++ b/foo_spider_monkey_panel/convert/js_to_native.h
@@ -158,7 +158,7 @@ T ToValue( JSContext* cx, JS::HandleValue jsValue )
 template <typename T>
 T ToValue( JSContext* cx, const JS::HandleString& jsString )
 {
-    static_assert( 0, "Unsupported type" );
+    static_assert( qwr::always_false_v<T>, "Unsupported type" );
 }
 
 template <>

--- a/foo_spider_monkey_panel/convert/native_to_js.h
+++ b/foo_spider_monkey_panel/convert/native_to_js.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <qwr/type_traits.h>
+
 namespace mozjs::convert::to_js
 {
 
@@ -12,7 +14,7 @@ void ToValue( JSContext* cx, const std::reference_wrapper<T>& inValue, JS::Mutab
 template <typename T>
 void ToValue( JSContext* cx, JS::Handle<T> inValue, JS::MutableHandleValue wrappedValue )
 {
-    static_assert( 0, "Unsupported type" );
+    static_assert( qwr::always_false_v<T>, "Unsupported type" );
 }
 
 template <>
@@ -24,7 +26,7 @@ void ToValue( JSContext* cx, JS::HandleValue inValue, JS::MutableHandleValue wra
 template <typename T>
 void ToValue( JSContext* cx, const T& inValue, JS::MutableHandleValue wrappedValue )
 {
-    static_assert( 0, "Unsupported type" );
+    static_assert( qwr::always_false_v<T>, "Unsupported type" );
 }
 
 template <>
@@ -86,7 +88,7 @@ void ToValue( JSContext* cx, const t_playback_queue_item& inValue, JS::MutableHa
 template <typename T>
 void ToValue( JSContext* cx, std::unique_ptr<T> inValue, JS::MutableHandleValue wrappedValue )
 {
-    static_assert( 0, "Unsupported type" );
+    static_assert( qwr::always_false_v<T>, "Unsupported type" );
 }
 
 template <>


### PR DESCRIPTION
- fix `static_asserts` being triggered in unspecialized JS &lt;-&gt; C++ value converters (on v143) using `qwr::always_false_v<T>`